### PR TITLE
pi: get stameska to build on rpi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: stameska
+
 STAMESKA_BASEDIR = .
 
 include stameska.mk

--- a/examples/triangles/gvertex.glsl
+++ b/examples/triangles/gvertex.glsl
@@ -45,11 +45,11 @@ vec3 CO =
 		vec3(hash(tn2+1.), hash(tn2+2.), hash(tn2+3.)), Tt2));
 vec3 CA =
 	3.*(-.5+mix(
-		vec3(hash(tn2+10), hash(tn2+11.), hash(tn2+12.)),
+		vec3(hash(tn2+10.), hash(tn2+11.), hash(tn2+12.)),
 		vec3(hash(tn2+11.), hash(tn2+12.), hash(tn2+13.)), Tt2));
 vec3 CU =
 	normalize(vec3(0.,1.,0.)+.8*(-.5+mix(
-		vec3(hash(tn2+20), hash(tn2+21.), hash(tn2+22.)),
+		vec3(hash(tn2+20.), hash(tn2+21.), hash(tn2+22.)),
 		vec3(hash(tn2+21.), hash(tn2+22.), hash(tn2+23.)), Tt2)));
 
 mat4 mproj = persp(0.01, 100., 3.1415927/2., R.x/R.y);

--- a/src/Export.cpp
+++ b/src/Export.cpp
@@ -214,6 +214,7 @@ Expected<void, std::string> exportC(const renderdesc::Pipeline &p, int w, int h,
 					comp = "GL_RGBA";
 					type = "GL_UNSIGNED_BYTE";
 					break;
+#ifndef ATTO_PLATFORM_RPI
 				case RGBA16F:
 					comp = "GL_RGBA16F";
 					type = "GL_FLOAT";
@@ -222,6 +223,7 @@ Expected<void, std::string> exportC(const renderdesc::Pipeline &p, int w, int h,
 					comp = "GL_RGBA32F";
 					type = "GL_FLOAT";
 					break;
+#endif
 			}
 
 			fprintf(f.get(), "\ttextureInit(textures[%d], %d, %d, %s, %s);\n",
@@ -355,9 +357,11 @@ Expected<void, std::string> exportC(const renderdesc::Pipeline &p, int w, int h,
 					case renderdesc::Command::Flag::DepthTest:
 						fprintf(f.get(), "\tglEnable(GL_DEPTH_TEST);\n");
 						break;
+#ifndef ATTO_PLATFORM_RPI
 					case renderdesc::Command::Flag::VertexProgramPointSize:
 						fprintf(f.get(), "\tglEnable(GL_VERTEX_PROGRAM_POINT_SIZE);\n");
 						break;
+#endif
 				}
 				break;
 			case renderdesc::Command::Op::Disable:
@@ -365,9 +369,11 @@ Expected<void, std::string> exportC(const renderdesc::Pipeline &p, int w, int h,
 					case renderdesc::Command::Flag::DepthTest:
 						fprintf(f.get(), "\tglDisable(GL_DEPTH_TEST);\n");
 						break;
+#ifndef ATTO_PLATFORM_RPI
 					case renderdesc::Command::Flag::VertexProgramPointSize:
 						fprintf(f.get(), "\tglDisable(GL_VERTEX_PROGRAM_POINT_SIZE);\n");
 						break;
+#endif
 				}
 				break;
 			case renderdesc::Command::Op::DrawArrays:

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -9,8 +9,14 @@
 #include <GL/gl.h>
 #include "glext.h"
 #else
+#ifdef ATTO_PLATFORM_RPI
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#define ATTO_GL_ES
+#else
 #define GL_GLEXT_PROTOTYPES
 #include <GL/gl.h>
+#endif
 #endif
 
 #define GL_FUNC_LIST(X) \
@@ -84,8 +90,10 @@ void GLCHECK(const char *func);
 
 enum PixelType {
 	RGBA8,
+#ifndef ATTO_PLATFORM_RPI
 	RGBA16F,
 	RGBA32F,
+#endif
 	//Depth24,
 };
 

--- a/src/PolledFile.cpp
+++ b/src/PolledFile.cpp
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 #endif
 
 #include <string>

--- a/src/Program.cpp
+++ b/src/Program.cpp
@@ -10,7 +10,7 @@ public:
 	static Expected<Shader,std::string> create(GLuint kind, const std::string& src) {
 		GLuint name = glCreateShader(kind);
 		GLchar const * const c_src = src.c_str();
-		glShaderSource(name, 1, &c_src, nullptr);
+		glShaderSource(name, 1, (const GLchar**)&c_src, nullptr);
 		glCompileShader(name);
 
 		GLint compiled = GL_FALSE;

--- a/src/RenderDesc.cpp
+++ b/src/RenderDesc.cpp
@@ -14,8 +14,10 @@ static Expected<PixelType, std::string> pixelTypeFromValue(const yaml::Value &v)
 
 	const std::string &s = s_result.value();
 	if (s == "RGBA8") return PixelType::RGBA8;
+#ifndef ATTO_PLATFORM_RPI
 	if (s == "RGBA16F") return PixelType::RGBA16F;
 	if (s == "RGBA32F") return PixelType::RGBA32F;
+#endif
 	//if (s == "Depth24") return PixelType::Depth24;
 
 	return Unexpected(format("Unexpected pixel type %s", s.c_str()));
@@ -28,7 +30,9 @@ static Expected<Command::Flag, std::string> flagFromValue(const yaml::Value &v) 
 
 	const std::string &s = s_result.value();
 	if (s == "DepthTest") return Command::Flag::DepthTest;
+#ifndef ATTO_PLATFORM_RPI
 	if (s == "VertexProgramPointSize") return Command::Flag::VertexProgramPointSize;
+#endif
 
 	return Unexpected(format("Unknown flag %s", s.c_str()));
 }

--- a/src/RenderDesc.h
+++ b/src/RenderDesc.h
@@ -48,7 +48,9 @@ public:
 
 	enum class Flag {
 		DepthTest,
+#ifndef ATTO_PLATFORM_RPI
 		VertexProgramPointSize,
+#endif
 	};
 
 	struct BindFramebuffer {

--- a/src/Texture.h
+++ b/src/Texture.h
@@ -39,6 +39,7 @@ public:
 				comp = GL_RGBA;
 				type = GL_UNSIGNED_BYTE;
 				break;
+#ifndef ATTO_PLATFORM_RPI
 			case RGBA16F:
 				comp = GL_RGBA16F;
 				type = GL_FLOAT;
@@ -47,6 +48,7 @@ public:
 				comp = GL_RGBA32F;
 				type = GL_FLOAT;
 				break;
+#endif
 		}
 
 		upload(w, h, comp, type, nullptr);

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 
 struct Value {
 	float x, y, z, w;

--- a/src/VideoEngine.cpp
+++ b/src/VideoEngine.cpp
@@ -70,9 +70,11 @@ bool VideoEngine::Framebuffer::attachColorTexture(int i, const Texture &tex) {
 
 #define MAX_PASS_TEXTURES 4
 
+#ifndef ATTO_PLATFORM_RPI
 static const GLuint draw_buffers[MAX_PASS_TEXTURES] = {
 	GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3
 };
+#endif
 
 VideoEngine::VideoEngine(const std::shared_ptr<renderdesc::Pipeline> &pipeline)
 	: pipeline_(pipeline)
@@ -152,7 +154,12 @@ static void useProgram(const PolledShaderProgram& program, int w, int h, float r
 }
 
 void VideoEngine::setCanvasResolution(int w, int h) {
+#ifndef ATTO_PLATFORM_RPI
 	canvas_.reset(new Canvas(w, h));
+#else
+	(void)w;
+	(void)h;
+#endif
 }
 
 void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_height, float row, Timeline &timeline) {
@@ -164,20 +171,29 @@ void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_h
 	glViewport(0, 0, preview_width, preview_height);
 	glClear(GL_COLOR_BUFFER_BIT);
 
+#ifndef ATTO_PLATFORM_RPI
 	if (!canvas_) {
 		glViewport(0, 0, preview_width, preview_height);
 		glClear(GL_COLOR_BUFFER_BIT);
 		return;
 	}
+#endif
 
 	struct {
 		int w, h;
 		const Program *program = nullptr;
 		// TODO better texture tracking mechanism to support texture changes between draw calls
 		int first_availabale_texture_slot = 0;
-	} runtime = { canvas_->width(), canvas_->height() };
+	} runtime = {
+		canvas_ ? canvas_->width() : preview_width,
+		canvas_ ? canvas_->height() : preview_height
+	};
 
+#ifndef ATTO_PLATFORM_RPI
 	GL(glBindFramebuffer(GL_FRAMEBUFFER, canvas_->framebuffer().name));
+#else
+	GL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+#endif
 	glViewport(0, 0, runtime.w, runtime.h);
 
 	for (const auto &cmd: pipeline_->commands) {
@@ -186,9 +202,15 @@ void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_h
 				{
 					const renderdesc::Command::BindFramebuffer &cmdfb = cmd.bindFramebuffer;
 					if (cmdfb.framebuffer.index == -1) {
-						GL(glBindFramebuffer(GL_FRAMEBUFFER, canvas_->framebuffer().name));
-						runtime.w = canvas_->width();
-						runtime.h = canvas_->height();
+						if (canvas_) {
+							GL(glBindFramebuffer(GL_FRAMEBUFFER, canvas_->framebuffer().name));
+							runtime.w = canvas_->width();
+							runtime.h = canvas_->height();
+						} else {
+							GL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+							runtime.w = preview_width;
+							runtime.h = preview_height;
+						}
 					} else {
 						const int index = cmdfb.framebuffer.index + pingpong[cmdfb.framebuffer.pingpong];
 
@@ -196,7 +218,9 @@ void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_h
 
 						const Framebuffer &fb = framebuffer_[index];
 						GL(glBindFramebuffer(GL_FRAMEBUFFER, fb.name));
+#ifndef ATTO_PLATFORM_RPI
 						GL(glDrawBuffers(fb.num_targets, draw_buffers));
+#endif
 						runtime.w = fb.w;
 						runtime.h = fb.h;
 					}
@@ -242,9 +266,11 @@ void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_h
 					case renderdesc::Command::Flag::DepthTest:
 						glEnable(GL_DEPTH_TEST);
 						break;
+#ifndef ATTO_PLATFORM_RPI
 					case renderdesc::Command::Flag::VertexProgramPointSize:
 						glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
 						break;
+#endif
 				}
 				break;
 			case renderdesc::Command::Op::Disable:
@@ -252,24 +278,32 @@ void VideoEngine::paint(unsigned int frame_seq, int preview_width, int preview_h
 					case renderdesc::Command::Flag::DepthTest:
 						glDisable(GL_DEPTH_TEST);
 						break;
+#ifndef ATTO_PLATFORM_RPI
 					case renderdesc::Command::Flag::VertexProgramPointSize:
 						glDisable(GL_VERTEX_PROGRAM_POINT_SIZE);
 						break;
+#endif
 				}
 				break;
 			case renderdesc::Command::Op::DrawArrays:
 				GL(glDrawArrays((GLenum)cmd.drawArrays.mode, cmd.drawArrays.start, cmd.drawArrays.count));
 				break;
 			case renderdesc::Command::Op::DrawFullscreen:
+#ifndef ATTO_PLATFORM_RPI
 				GL(glRects(-1,-1,1,1));
+#else
+// FIXME
+#endif
 				break;
 		}
 	}
 
+#ifndef ATTO_PLATFORM_RPI
 	GL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 	glViewport(0, 0, preview_width, preview_height);
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, canvas_->color().name());
 	canvas_->program().use().setUniform("R", preview_width, preview_height).setUniform("frame", 0);
 	glRects(-1,-1,1,1);
+#endif
 } // void VideoEngine::paint()

--- a/src/YamlParser.cpp
+++ b/src/YamlParser.cpp
@@ -3,6 +3,7 @@
 
 #include "yaml.h"
 #include <stdio.h>
+#include <errno.h>
 #include <stdexcept>
 #include <memory>
 

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -3,8 +3,10 @@
 
 #include "video.h"
 #include "utils.h"
+#ifndef ATTO_PLATFORM_RPI
 #define AUDIO_IMPLEMENT
 #include "aud_io.h"
+#endif
 #include "atto/app.h"
 #include "atto/platform.h"
 
@@ -23,6 +25,7 @@ static struct {
 	int set;
 } loop;
 
+#ifndef ATTO_PLATFORM_RPI
 static void audioCallback(void *unused, float *samples, int nsamples) {
 	(void)unused;
 	if (loop.paused || !settings.audio.data) {
@@ -42,6 +45,7 @@ static void audioCallback(void *unused, float *samples, int nsamples) {
 				loop.pos = loop.start;
 	}
 }
+#endif
 
 static void resize(ATimeUs ts, unsigned int w, unsigned int h) {
 	(void)ts;
@@ -189,5 +193,7 @@ void attoAppInit(struct AAppProctable *proctable) {
 			return !loop.paused.load();
 		}
 	));
+#ifndef ATTO_PLATFORM_RPI
 	audioOpen(settings.audio.samplerate, settings.audio.channels, nullptr, audioCallback, nullptr, nullptr);
+#endif
 }

--- a/stameska.mk
+++ b/stameska.mk
@@ -31,9 +31,11 @@ ifeq ($(ASAN), 1)
 	LIBS += -fsanitize=address
 endif
 
-COMPILE.cc = $(CXX) $(CXXFLAGS) $(DEPFLAGS) -MT $@ -MF $@.d
+ifneq ($(RASPBERRY), 1)
+	LIBS += -lasound
+endif
 
-all: stameska
+COMPILE.cc = $(CXX) $(CXXFLAGS) $(DEPFLAGS) -MT $@ -MF $@.d
 
 $(OBJDIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)

--- a/stameska.mk
+++ b/stameska.mk
@@ -1,13 +1,11 @@
-.SUFFIXES:
-.DEFAULT:
-MAKEFLAGS += -r --no-print-directory
+ATTO_BASEDIR=3p/atto
+include 3p/atto/atto.mk
 
 BUILDDIR ?= build
 CC ?= cc
 CXX ?= c++
-CFLAGS += -Wall -Wextra -Werror -pedantic -I$(STAMESKA_BASEDIR) -I$(STAMESKA_BASEDIR)/3p/atto -I$(STAMESKA_BASEDIR)/3p -I$(STAMESKA_BASEDIR)/src
+CFLAGS += -I$(STAMESKA_BASEDIR) -I$(STAMESKA_BASEDIR)/3p -I$(STAMESKA_BASEDIR)/src
 CXXFLAGS += -std=c++17 -fno-exceptions -fno-rtti $(CFLAGS)
-LIBS = -lX11 -lXfixes -lGL -lasound -lm -pthread
 
 YAML_MAJOR=0
 YAML_MINOR=2
@@ -24,11 +22,7 @@ CFLAGS += \
 	-DYAML_VERSION_STRING="\"$(YAML_MAJOR).$(YAML_MINOR).$(YAML_PATCH)\""
 
 ifeq ($(DEBUG), 1)
-	CONFIG = dbg
-	CFLAGS += -O0 -g -DDEBUG
-else
-	CONFIG = rel
-	CFLAGS += -O3
+	CFLAGS += -DDEBUG
 endif
 
 ifeq ($(ASAN), 1)
@@ -37,20 +31,9 @@ ifeq ($(ASAN), 1)
 	LIBS += -fsanitize=address
 endif
 
-PLATFORM=linux-x11
-COMPILER ?= $(CC)
-
-DEPFLAGS = -MMD -MP
-COMPILE.c = $(CC) -std=gnu99 $(CFLAGS) $(DEPFLAGS) -MT $@ -MF $@.d
 COMPILE.cc = $(CXX) $(CXXFLAGS) $(DEPFLAGS) -MT $@ -MF $@.d
 
-OBJDIR ?= $(BUILDDIR)/$(PLATFORM)-$(CONFIG)
-
 all: stameska
-
-$(OBJDIR)/%.c.o: %.c
-	@mkdir -p $(dir $@)
-	$(COMPILE.c) -c $< -o $@
 
 $(OBJDIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
@@ -66,8 +49,6 @@ LIBYAML_SOURCES= \
 STAMESKA_EXE = $(OBJDIR)/stameska
 STAMESKA_SOURCES += \
 	$(LIBYAML_SOURCES) \
-	$(STAMESKA_BASEDIR)/3p/atto/src/app_linux.c \
-	$(STAMESKA_BASEDIR)/3p/atto/src/app_x11.c \
 	$(STAMESKA_BASEDIR)/src/Export.cpp \
 	$(STAMESKA_BASEDIR)/src/OpenGL.cpp \
 	$(STAMESKA_BASEDIR)/src/PolledFile.cpp \
@@ -86,7 +67,6 @@ STAMESKA_SOURCES += \
 	$(STAMESKA_BASEDIR)/src/format.cpp \
 	$(STAMESKA_BASEDIR)/src/video.cpp \
 
-# TODO how to handle ../
 STAMESKA_OBJS = $(STAMESKA_SOURCES:%=$(OBJDIR)/%.o)
 STAMESKA_DEPS = $(STAMESKA_OBJS:%=%.d)
 -include $(STAMESKA_DEPS)
@@ -94,12 +74,9 @@ STAMESKA_DEPS = $(STAMESKA_OBJS:%=%.d)
 $(STAMESKA_BASEDIR)/3p/rocket/lib/librocket.a:
 	MAKEFLAGS= make -C $(STAMESKA_BASEDIR)/3p/rocket lib/librocket.a
 
-$(STAMESKA_EXE): $(STAMESKA_OBJS) $(STAMESKA_BASEDIR)/3p/rocket/lib/librocket.a
-	$(CXX) $^ $(STAMESKA_BASEDIR)/3p/rocket/lib/librocket.a $(LIBS) -o $@
+$(STAMESKA_EXE): $(ATTO_OBJS) $(STAMESKA_OBJS) $(STAMESKA_BASEDIR)/3p/rocket/lib/librocket.a
+	$(CXX) $(CXXFLAGS) $^ $(STAMESKA_BASEDIR)/3p/rocket/lib/librocket.a $(LIBS) -o $@
 
 stameska: $(STAMESKA_EXE)
-
-clean:
-	rm -rf build
 
 .PHONY: all clean

--- a/stameska.vcxproj
+++ b/stameska.vcxproj
@@ -152,7 +152,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto\include;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -168,7 +168,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto\include;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -186,7 +186,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto\include;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -206,7 +206,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir)3p\atto\include;$(ProjectDir)3p;$(ProjectDir)src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>


### PR DESCRIPTION
No examples work:
- fullscreen shaders aren't supported: don't make much sense on rpi, mem
bandwidth is too slow; also, glRects doesn't exist, and user should
manually write vertex shaders to cover the entire screen.
- existing geometry generation doesn't work because it requires
gl_VertexID, which doesn't exist in GLES2

Also, building requires C++17 and string_view, which aren't available on
stock raspbian.

The only toolchain that works is:
wget https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
tar xJf clang+llvm-8.0.0-armv7a-linux-gnueabihf.tar.xz
export PATH=$(pwd)/clang+llvm-8.0.0-armv7a-linux-gnueabihf/bin:$PATH
export LD_LIBRARY_PATH=$(pwd)/clang+llvm-8.0.0-armv7a-linux-gnueabihf/bin:$LD_LIBRARY_PATH

Then build like:
CXXFLAGS='-stdlib=libc++' make DEBUG=1 CC=clang-8 CXX=clang++ RASPBERRY=1 -j4 stameska